### PR TITLE
Rework sending and receiving methods

### DIFF
--- a/SMPCbox/AbstractProtocol.py
+++ b/SMPCbox/AbstractProtocol.py
@@ -155,19 +155,18 @@ class AbstractProtocol (ABC):
         variables = [variables] if type(variables) == str else variables
         variable_values = {}
 
-        # TODO change the send and receive methods for protocol parties to send multiple variables as one message.
-        for var in variables:
-            # only call the send and receive methods on the parties if that party is running localy.
-            if (self.is_local_party(sending_party)):
-                sending_party.send_variable(receiving_party, var)
-                variable_values[var] = sending_party.get_variable(var)
-            
-            if (self.is_local_party(receiving_party)):
-                receiving_party.receive_variable(sending_party, var)
-                if var not in variable_values.keys():
-                    # TODO set to none when the get_variable becomes blocking.
-                    # TODO add a ReceivedVar to the protocolOpps
-                    variable_values[var] = receiving_party.get_variable(var)
+        # only call the send and receive methods on the parties if that party is running localy.
+        if (self.is_local_party(sending_party)):
+            sending_party.send_variables(receiving_party, variables)
+            for var in variables:
+                variable_values[var] = sending_party.get_variable(var) 
+        
+        if (self.is_local_party(receiving_party)):
+            receiving_party.receive_variables(sending_party, variables)
+            if (not self.is_local_party(sending_party)):
+                for var in variables:
+                    # The variable is posibly not received yet.
+                    variable_values[var] = None
         
         # add the description
         self.protocol_steps[-1].add_opperation(SendVariables(sending_party, receiving_party, variable_values))

--- a/SMPCbox/ProtocolParty.py
+++ b/SMPCbox/ProtocolParty.py
@@ -86,14 +86,17 @@ class ProtocolParty ():
     def set_local_variable(self, variable_name: str, value: Any):
         self.__local_variables[self.get_namespace() + variable_name] = value
 
-    def send_variable (self, receiver: Type['ProtocolParty'], variable_name: str):
-        real_var_name = self.get_namespace() + variable_name
-        self.socket.send_variable(receiver, real_var_name, self.get_variable(variable_name))
+    def send_variables (self, receiver: Type['ProtocolParty'], variable_names: list[str]):
+        name_spaced_names = [self.get_namespace() + name for name in variable_names]
+        values = [self.get_variable(var) for var in name_spaced_names]
+        self.socket.send_variables(receiver, name_spaced_names, values)
 
-    def receive_variable (self, sender: Type['ProtocolParty'], variable_name: str):
-        real_var_name = self.get_namespace() + variable_name
-        # add the variable to the not_yet_received_vars
-        self.not_yet_received_vars[real_var_name] = sender
+    def receive_variables (self, sender: Type['ProtocolParty'], variable_names: list[str]):
+        variable_names = [self.get_namespace() + name for name in variable_names]
+        
+        # add the variables to the not_yet_received_vars
+        for name in variable_names:
+            self.not_yet_received_vars[name] = sender
 
     """ should be called to make sure the sockets exit nicely """
     def exit_protocol(self):

--- a/SMPCbox/SMPCSocket.py
+++ b/SMPCbox/SMPCSocket.py
@@ -56,9 +56,18 @@ class SMPCSocket ():
                     # TODO create a setting for buffer size
                     data = socket.recv(4096)
                     if data:
-                        sender_name, var_name, value = data.decode().split()
-                        value = json.loads(value)
-                        self.put_variable_in_buffer(sender_name, var_name, value)
+                        sender_name, *variables = data.decode().split()
+
+                        var_names = []
+                        values = []
+                        for i in range(0, len(variables), 2):
+                            var_name = variables[i]
+                            value = json.loads(variables[i+1])
+
+                            var_names.append(var_name)
+                            values.append(value)
+
+                        self.put_variables_in_buffer(sender_name, var_names, values)
                     else:
                         socket.close()
                         self.client_sockets.remove(socket)
@@ -92,11 +101,13 @@ class SMPCSocket ():
         return None
         
 
-    def put_variable_in_buffer (self, sender_name: str, variable_name: str, value: Any):
+    def put_variables_in_buffer (self, sender_name: str, variable_names: list[str], values: list[Any]):
         if not sender_name in self.received_variables.keys():
             self.received_variables[sender_name] = {}
-
-        self.received_variables[sender_name][variable_name] = value
+        
+        # add all the provided variables
+        for var, val in zip(variable_names, values):
+            self.received_variables[sender_name][var] = val
     
     """
     Stores a received_variables in the buffer
@@ -130,7 +141,6 @@ class SMPCSocket ():
                 time.sleep(0.1)
     
             raise Exception(f"The variable \"{variable_name}\" has not been received from the party \"{sender.name}\"")
-            self.close()
         else:
             value = self.get_variable_from_buffer(sender.name, variable_name)
             return value
@@ -138,7 +148,7 @@ class SMPCSocket ():
     """
     This function sends the variable to this socket. 
     """
-    def send_variable (self, receiver: Type['ProtocolParty'], variable_name: str, value: Any):
+    def send_variables (self, receiver: Type['ProtocolParty'], variable_names: list[str], values: list[Any]):
         receiver_socket: Type['SMPCSocket'] = receiver.socket
         if self.ip:
             # check for an existing connection
@@ -153,8 +163,13 @@ class SMPCSocket ():
                 existing_socket = new_client
             
             # send the message
-            msg = f"{self.name} {variable_name} {json.dumps(value)}"
+            msg = f"{self.name}"
+
+            # Add all the variables
+            for var, val in zip(variable_names, values):
+                msg += f" {var} {json.dumps(val)}"
+
             existing_socket.sendall(msg.encode())
         else: 
             # we simulate the socket by putting the variable in the buffer of received variables
-            receiver_socket.put_variable_in_buffer(self.name, variable_name, value)
+            receiver_socket.put_variables_in_buffer(self.name, variable_names, values)

--- a/implementedProtocols/OT.py
+++ b/implementedProtocols/OT.py
@@ -73,12 +73,13 @@ class OT(AbstractProtocol):
 if __name__ == "__main__":
     ot_protocol = OT()
 
-    sender = ProtocolParty("Alice", address="127.0.0.1:4845")
-    receiver = ProtocolParty("Bob", address="127.0.0.1:4846", is_listening_socket=False)
+    sender = ProtocolParty("Alice", address="127.0.0.1:4841")
+    receiver = ProtocolParty("Bob", address="127.0.0.1:4840", is_listening_socket=False)
     time.sleep(5)
     ot_protocol.set_protocol_parties({"Sender": sender, "Receiver": receiver})
     ot_protocol.set_running_party("Sender", sender)
-    ot_protocol.set_input({"Sender": {"m0": 1, "m1": 29}})#, "Receiver": {"b": 1}})
+    ot_protocol.set_input({"Sender": {"m0": 1, "m1": 29}})
+    # ot_protocol.set_input({"Sender": {"m0": 1, "m1": 29}, "Receiver": {"b": 1}})
     ot_protocol()
 
     for step in ot_protocol.protocol_steps:

--- a/implementedProtocols/client2.py
+++ b/implementedProtocols/client2.py
@@ -7,8 +7,8 @@ import time
 if __name__ == "__main__":
     ot_protocol = OT()
 
-    sender = ProtocolParty("Alice", address="127.0.0.1:4845", is_listening_socket=False)
-    receiver = ProtocolParty("Bob", address="127.0.0.1:4846")
+    sender = ProtocolParty("Alice", address="127.0.0.1:4841", is_listening_socket=False)
+    receiver = ProtocolParty("Bob", address="127.0.0.1:4840")
     time.sleep(5)
     ot_protocol.set_protocol_parties({"Sender": sender, "Receiver": receiver})
     ot_protocol.set_running_party("Receiver", receiver)


### PR DESCRIPTION
Reworked the variable sending and receiving.
The protocolParty now stores the "received" variables and only requests them from the socket when the variable is used in a computation.
The sending of multiple variables is now done in a single message instead of needing a message for each variable.